### PR TITLE
Wiadomości hebe - dużo poprawek

### DIFF
--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/Hebe.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/Hebe.kt
@@ -328,6 +328,13 @@ class Hebe {
             status = status,
         )
 
+    suspend fun markMessageRead(pupilId: Int?, boxKey: String, messageKey: String): Boolean? = studentRepository
+        .markMessageRead(
+            pupilId = pupilId,
+            boxKey = boxKey,
+            messageKey = messageKey
+        )
+
     suspend fun sendMessage(subject: String, content: String, recipients: List<MessageUser>, sender: MessageUser) = studentRepository
         .sendMessage(
             subject = subject,

--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/models/MarkMessageReadRequest.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/models/MarkMessageReadRequest.kt
@@ -1,0 +1,14 @@
+package io.github.wulkanowy.sdk.hebe.models
+
+import kotlinx.serialization.SerialName
+
+data class MarkMessageReadRequest(
+    @SerialName("PupilId")
+    val pupilId: Int? = null,
+    @SerialName("BoxKey")
+    val boxKey: String,
+    @SerialName("MessageKey")
+    val messageKey: String,
+    @SerialName("Status")
+    val status: Int = 1,
+)

--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/models/MarkMessageReadRequest.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/models/MarkMessageReadRequest.kt
@@ -1,7 +1,9 @@
 package io.github.wulkanowy.sdk.hebe.models
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class MarkMessageReadRequest(
     @SerialName("PupilId")
     val pupilId: Int? = null,

--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/models/Message.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/models/Message.kt
@@ -61,6 +61,8 @@ data class Message(
         val globalKey: String,
         @SerialName("Name")
         val name: String,
+        @SerialName("HasRead")
+        val hasRead: Int? = null
     )
 
     @Serializable

--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/repository/StudentRepository.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/repository/StudentRepository.kt
@@ -7,6 +7,7 @@ import io.github.wulkanowy.sdk.hebe.models.Grade
 import io.github.wulkanowy.sdk.hebe.models.GradeAverage
 import io.github.wulkanowy.sdk.hebe.models.GradeSummary
 import io.github.wulkanowy.sdk.hebe.models.LuckyNumber
+import io.github.wulkanowy.sdk.hebe.models.MarkMessageReadRequest
 import io.github.wulkanowy.sdk.hebe.models.Message
 import io.github.wulkanowy.sdk.hebe.models.MessageUser
 import io.github.wulkanowy.sdk.hebe.models.SendMessageRequest
@@ -175,6 +176,19 @@ internal class StudentRepository(
                     ),
                 ),
             ),
+        ).getEnvelopeOrThrowError()
+
+    suspend fun markMessageRead(pupilId: Int?, boxKey: String, messageKey: String) = studentService
+        .markMessageRead(
+            ApiRequest(
+                envelope = listOf(
+                    MarkMessageReadRequest(
+                        pupilId = pupilId,
+                        boxKey = boxKey,
+                        messageKey = messageKey
+                    )
+                )
+            )
         ).getEnvelopeOrThrowError()
 
     suspend fun sendMessage(subject: String, content: String, recipients: List<MessageUser>, sender: MessageUser): Message? {

--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/repository/StudentRepository.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/repository/StudentRepository.kt
@@ -181,12 +181,10 @@ internal class StudentRepository(
     suspend fun markMessageRead(pupilId: Int?, boxKey: String, messageKey: String) = studentService
         .markMessageRead(
             ApiRequest(
-                envelope = listOf(
-                    MarkMessageReadRequest(
-                        pupilId = pupilId,
-                        boxKey = boxKey,
-                        messageKey = messageKey
-                    )
+                envelope = MarkMessageReadRequest(
+                    pupilId = pupilId,
+                    boxKey = boxKey,
+                    messageKey = messageKey
                 )
             )
         ).getEnvelopeOrThrowError()

--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/service/StudentService.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/service/StudentService.kt
@@ -81,7 +81,7 @@ internal interface StudentService {
     suspend fun setStatus(@Body request: ApiRequest<List<SetMessageStatusRequest>>): ApiResponse<Boolean>
 
     @POST("api/mobile/messages/status")
-    suspend fun markMessageRead(@Body request: ApiRequest<List<MarkMessageReadRequest>>): ApiResponse<Boolean>
+    suspend fun markMessageRead(@Body request: ApiRequest<MarkMessageReadRequest>): ApiResponse<Boolean>
 
     @POST("api/mobile/messages")
     suspend fun sendMessage(@Body request: ApiRequest<SendMessageRequest>): ApiResponse<Message>

--- a/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/service/StudentService.kt
+++ b/sdk-hebe/src/main/kotlin/io/github/wulkanowy/sdk/hebe/service/StudentService.kt
@@ -11,6 +11,7 @@ import io.github.wulkanowy.sdk.hebe.models.Homework
 import io.github.wulkanowy.sdk.hebe.models.Lesson
 import io.github.wulkanowy.sdk.hebe.models.LuckyNumber
 import io.github.wulkanowy.sdk.hebe.models.Mailbox
+import io.github.wulkanowy.sdk.hebe.models.MarkMessageReadRequest
 import io.github.wulkanowy.sdk.hebe.models.Meeting
 import io.github.wulkanowy.sdk.hebe.models.Message
 import io.github.wulkanowy.sdk.hebe.models.Note
@@ -78,6 +79,9 @@ internal interface StudentService {
 
     @POST("api/mobile/messages/statuses")
     suspend fun setStatus(@Body request: ApiRequest<List<SetMessageStatusRequest>>): ApiResponse<Boolean>
+
+    @POST("api/mobile/messages/status")
+    suspend fun markMessageRead(@Body request: ApiRequest<List<MarkMessageReadRequest>>): ApiResponse<Boolean>
 
     @POST("api/mobile/messages")
     suspend fun sendMessage(@Body request: ApiRequest<SendMessageRequest>): ApiResponse<Message>

--- a/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/Scrapper.kt
+++ b/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/Scrapper.kt
@@ -592,6 +592,8 @@ class Scrapper {
 
     suspend fun getMessageDetails(globalKey: String, markAsRead: Boolean): MessageDetails = messages.getMessageDetails(globalKey, markAsRead)
 
+    suspend fun markMessageRead(globalKey: String) = messages.markMessageRead(globalKey)
+
     suspend fun sendMessage(subject: String, content: String, recipients: List<String>, senderMailboxId: String) =
         messages.sendMessage(subject, content, recipients, senderMailboxId)
 

--- a/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/Scrapper.kt
+++ b/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/Scrapper.kt
@@ -590,7 +590,7 @@ class Scrapper {
 
     suspend fun getMessageReplayDetails(globalKey: String): MessageReplayDetails = messages.getMessageReplayDetails(globalKey)
 
-    suspend fun getMessageDetails(globalKey: String, markAsRead: Boolean): MessageDetails = messages.getMessageDetails(globalKey, markAsRead)
+    suspend fun getMessageDetails(globalKey: String): MessageDetails = messages.getMessageDetails(globalKey)
 
     suspend fun markMessageRead(globalKey: String) = messages.markMessageRead(globalKey)
 

--- a/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/repository/MessagesRepository.kt
+++ b/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/repository/MessagesRepository.kt
@@ -95,12 +95,8 @@ internal class MessagesRepository(
         }
     }
 
-    suspend fun getMessageDetails(globalKey: String, markAsRead: Boolean): MessageDetails {
-        val details = api.getMessageDetails(globalKey) ?: error("Message not exist")
-        if (markAsRead) {
-            markMessageRead(globalKey)
-        }
-        return details
+    suspend fun getMessageDetails(globalKey: String): MessageDetails {
+        return api.getMessageDetails(globalKey) ?: error("Message not exist")
     }
 
     suspend fun markMessageRead(globalKey: String) {

--- a/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/repository/MessagesRepository.kt
+++ b/sdk-scrapper/src/main/kotlin/io/github/wulkanowy/sdk/scrapper/repository/MessagesRepository.kt
@@ -98,14 +98,18 @@ internal class MessagesRepository(
     suspend fun getMessageDetails(globalKey: String, markAsRead: Boolean): MessageDetails {
         val details = api.getMessageDetails(globalKey) ?: error("Message not exist")
         if (markAsRead) {
-            runCatching {
-                loginModule()
-                api.markMessageAsRead(body = mapOf("apiGlobalKey" to globalKey))
-            }
-                .onFailure { logger.error("Error occur while marking message as read", it) }
-                .getOrNull()
+            markMessageRead(globalKey)
         }
         return details
+    }
+
+    suspend fun markMessageRead(globalKey: String) {
+        runCatching {
+            loginModule()
+            api.markMessageAsRead(body = mapOf("apiGlobalKey" to globalKey))
+        }
+            .onFailure { logger.error("Error occur while marking message as read", it) }
+            .getOrNull()
     }
 
     suspend fun sendMessage(subject: String, content: String, recipients: List<String>, senderMailboxId: String) {

--- a/sdk/src/main/kotlin/io/github/wulkanowy/sdk/Sdk.kt
+++ b/sdk/src/main/kotlin/io/github/wulkanowy/sdk/Sdk.kt
@@ -637,9 +637,9 @@ class Sdk {
         }
     }
 
-    suspend fun getMessageDetails(messageKey: String, markAsRead: Boolean = true): MessageDetails = withContext(Dispatchers.IO) {
+    suspend fun getMessageDetails(messageKey: String): MessageDetails = withContext(Dispatchers.IO) {
         when (mode) {
-            Mode.HYBRID, Mode.SCRAPPER -> scrapper.getMessageDetails(messageKey, markAsRead).mapScrapperMessage()
+            Mode.HYBRID, Mode.SCRAPPER -> scrapper.getMessageDetails(messageKey).mapScrapperMessage()
             Mode.HEBE -> throw NotImplementedError("Not available in HEBE mode")
         }
     }

--- a/sdk/src/main/kotlin/io/github/wulkanowy/sdk/Sdk.kt
+++ b/sdk/src/main/kotlin/io/github/wulkanowy/sdk/Sdk.kt
@@ -644,6 +644,13 @@ class Sdk {
         }
     }
 
+    suspend fun markMessageRead(boxKey: String, messageKey: String) {
+        when (mode) {
+            Mode.SCRAPPER -> scrapper.markMessageRead(messageKey)
+            Mode.HYBRID, Mode.HEBE -> hebe.markMessageRead(hebe.pupilId, boxKey, messageKey)
+        }
+    }
+
     suspend fun sendMessage(subject: String, content: String, recipients: List<Recipient>, senderName: String, senderKey: String, partition: String) = withContext(
         Dispatchers.IO,
     ) {

--- a/sdk/src/main/kotlin/io/github/wulkanowy/sdk/Utils.kt
+++ b/sdk/src/main/kotlin/io/github/wulkanowy/sdk/Utils.kt
@@ -1,5 +1,6 @@
 package io.github.wulkanowy.sdk
 
+import io.github.wulkanowy.sdk.pojo.MailboxType
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -24,3 +25,19 @@ fun String.normalizeRecipient() = substringBeforeLast("-")
     .substringBefore(" [")
     .substringBeforeLast(" (")
     .trim()
+
+fun String.extractNameFromRecipient(): String  = substringBeforeLast(" - ")
+        .substringBeforeLast(" - ")
+        .trim()
+
+fun String.extractSchoolShortFromRecipient(): String  = substringAfterLast(" - ")
+    .replace("(", "")
+    .replace(")", "")
+    .trim()
+
+fun String.extractTypeFromRecipient(): MailboxType = MailboxType
+    .fromLetter(
+        substringBeforeLast(" - ")
+        .substringAfterLast(" - ")
+        .trim()
+    )

--- a/sdk/src/main/kotlin/io/github/wulkanowy/sdk/mapper/MessagesMapper.kt
+++ b/sdk/src/main/kotlin/io/github/wulkanowy/sdk/mapper/MessagesMapper.kt
@@ -101,7 +101,7 @@ internal fun List<HebeMessage>.mapMessages(zoneId: ZoneId, folderId: Folder) = m
             ),
         ),
         correspondents = it.sender.name,
-        unread = false,
+        unread = it.dateRead == null,
         unreadBy = 0,
         readBy = 0,
         hasAttachments = it.attachments.isNotEmpty(),

--- a/sdk/src/main/kotlin/io/github/wulkanowy/sdk/mapper/RecipientMapper.kt
+++ b/sdk/src/main/kotlin/io/github/wulkanowy/sdk/mapper/RecipientMapper.kt
@@ -1,5 +1,8 @@
 package io.github.wulkanowy.sdk.mapper
 
+import io.github.wulkanowy.sdk.extractNameFromRecipient
+import io.github.wulkanowy.sdk.extractSchoolShortFromRecipient
+import io.github.wulkanowy.sdk.extractTypeFromRecipient
 import io.github.wulkanowy.sdk.pojo.MailboxType
 import io.github.wulkanowy.sdk.pojo.Recipient
 import io.github.wulkanowy.sdk.hebe.models.Recipient as HebeRecipient
@@ -30,11 +33,7 @@ internal fun HebeRecipient.mapToRecipient() = Recipient(
     mailboxGlobalKey = globalKey,
     fullName = name,
     userName = name,
-    studentName = name.split(" - ")[0],
-    schoolNameShort = name
-        .split(" - ")
-        .last()
-        .replace("(", "")
-        .replace(")", ""),
-    type = MailboxType.fromLetter(group),
+    studentName = name.extractNameFromRecipient(),
+    schoolNameShort = name.extractSchoolShortFromRecipient(),
+    type = name.extractTypeFromRecipient(),
 )


### PR DESCRIPTION
### Zmiany:

 - Dodałem funkcję do oznaczania wiadomości jako przeczytanej (w scrapperze i hebe) - jest to potrzebne do zrobienia normalnej obsługi wiadomości (dotychczas nie były one w ogóle odczytywane) i do https://github.com/wezuwiusz/neowulkanowy/pull/1
 - Ze względu na hebe wiadomości ze scrappera nie są automatycznie oznaczane jako przeczytane, teraz robi to apka

### Poprawki:

 - Naprawiłem dużo metadanych wiadomości
 - Zmieniłem sposób w jaki moduł od hebe "nazywa" korespondentów - teraz jest tak jak w scrapperze (chyba) i przy okazji poprawiłem wyświetlanie dwuczłonowych nazwisk nauczycieli
 - Hebe zwraca teraz odbiorcę zamiast nadawcy w wysłanych wiadomościach

### Do zrobienia:

 - ~~Check czy wiadomość jest wysłana czy odebrana nie działa w wiadomościach z kosza~~ To to nie jestem pewien czy naprawię bo nie wiem jak to zrobić bez porównywania id skrzynki (przez co konieczne byłoby dużo kombinowania), do plakietek czy wiadomość jest przeczytana zrobiłem check czy wiadomość nie jest w koszu (bo tam są raczej niepotrzebne) a jest to jedyne miejsce chyba gdzie jest to używane, więc nie wiem czy warto na to tracić czas.